### PR TITLE
fix results dir output filepath

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -83,5 +83,5 @@ rule gen_new_features:
 			--abc_predictions {input.abc_predictions} \
 			--ref_gene_tss {params.gene_TSS500} \
 			--chr_sizes {params.chr_sizes} \
-			--results_dir {RESULTS_DIR}{wildcards.dataset}
+			--results_dir {RESULTS_DIR}/{wildcards.dataset}
 		"""


### PR DESCRIPTION
i was outputting results to  `e2g_features_resultsK562` instead of `e2g_features_results/K562`

## Test Plan
Ran via snakemake and output directory looks as expected `e2g_features_results/K562`