### PR TITLE
s/dnase_only/activity_only

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -23,7 +23,7 @@ rule all:
 			os.path.join(RESULTS_DIR, "{dataset}", "EPCrisprBenchmark_ensemble_data_GRCh38.K562_ActivityOnly_features_{nafill}.tsv.gz"), nafill = ["withNA", "NAfilled"], dataset=dataset_config['dataset']
 		)
 
-# create DNase-only feature table
+# create activity-only feature table
 rule activity_only_features:
 	input:
 		feature_config = "config/feature_config.tsv",
@@ -40,9 +40,9 @@ rule activity_only_features:
 	conda:
 		"envs/encode_e2g_features.yml"
 	script:
-		"scripts/dnase_only_features.R"
+		"scripts/activity_only_features.R"
 
-# overlap DNase-only feature table table with K562 CRISPR data
+# overlap activity-only feature table table with K562 CRISPR data
 rule overlap_activity_only_features_crispr:
 	input:
 		features = os.path.join(RESULTS_DIR, "{dataset}/ActivityOnly_features.tsv.gz"),


### PR DESCRIPTION
The dnase r script supports ATAC now, so we should rename the files/variables/comments accordingly. 

## Test Plan
Ran snakemake successfully 

Put "DNase" as activity and got error as expected
```
[Mon Aug 28 16:13:27 2023]
rule activity_only_features:
    input: config/feature_config.tsv, /oak/stanford/groups/engreitz/Users/atan5133/e2g_pipeline/results/abc_results/K562_chr22/Predictions/EnhancerPredictionsAllPutative.tsv.gz, /oak/stanford/groups/engreitz/Users/atan5133/e2g_pipeline/results/e2g_features_results/K562_chr22/NumCandidateEnhGene.tsv, /oak/stanford/groups/engreitz/Users/atan5133/e2g_pipeline/results/e2g_features_results/K562_chr22/NumTSSEnhGene.tsv, /oak/stanford/groups/engreitz/Users/atan5133/e2g_pipeline/results/e2g_features_results/K562_chr22/NumEnhancersEG5kb.txt, /oak/stanford/groups/engreitz/Users/atan5133/e2g_pipeline/results/e2g_features_results/K562_chr22/SumEnhancersEG5kb.txt, resources/for_classifier_use_ubiquitous_expression_RefSeqCurated.170308.bed.CollapsedGeneBounds.hg38.TSS500bp.txt
    output: /oak/stanford/groups/engreitz/Users/atan5133/e2g_pipeline/results/e2g_features_results/K562_chr22/ActivityOnly_features.tsv.gz
    jobid: 2
    reason: Params have changed since last execution
    wildcards: dataset=K562_chr22
    resources: tmpdir=/tmp

Activating conda environment: .snakemake/conda/8f04a3ea6732c34d68852f1823ea94f2_
Error: Only DHS or ATAC activity param supported
```